### PR TITLE
Multiline caption, figure options and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An extension to the [Python Markdown](https://pypi.python.org/pypi/Markdown) package.
 
-The exension wraps all images in the markdown document or text in `<figure>` tags, inserting a `<figcaption>` as well by re-using the `img alt` tag from markdown syntax (text in square brackets).
+The extension wraps all images in the markdown document or text in `<figure>` tags, inserting a `<figcaption>` as well by re-using the `img alt` tag from markdown syntax (text in square brackets).
 
 To install use `pip install markdown-figure` or use the repository `pip install git+https://github.com/janwh/markdown-figure.git`
 
@@ -16,4 +16,32 @@ md = markdown.Markdown(extensions=[FigureExtension()])
 
 # Wrap an Image
 md.convert('![my description](image.jpg)')
+```
+
+## Configuration
+
+| Name                 | Description                                           | Default |
+| -------------------- | ----------------------------------------------------- | ------- |
+| `figure_classes`     | Class attributes assigned to the `<figure />` tag     | `None`  |
+| `img_classes`        | Class attributes assigned to the `<img />` tag        | `None`  |
+| `figcaption_classes` | Class attributes assigned to the `<figcaption />` tag | `None`  |
+| `multiline`          | Support line breaks in the `<figcaption />` tag       | `True`  |
+
+## Options
+
+The fragment of the image `src` link is available in `<figure data-options=""/>`.
+
+Example of the right alignment.
+
+```python
+# Wrap an Image with "right" option
+md.convert('![my description  \nsecond line](image.jpg#right)')
+```
+
+With custom CSS.
+
+```css
+figure[data-options~="right"] {
+  float: right;
+}
 ```

--- a/mdfigure.py
+++ b/mdfigure.py
@@ -73,3 +73,8 @@ class FigureExtension(Extension):
                                       self.getConfig('figcaption_classes'))
         md.treeprocessors.add("figure", figures, "_end")
         md.registerExtension(self)
+
+
+def makeExtension(*args, **kwargs):
+    """ Return extension. """
+    return FigureExtension(*args, **kwargs)

--- a/mdfigure.py
+++ b/mdfigure.py
@@ -30,6 +30,7 @@ class FigureTreeprocessor(Treeprocessor):
         images = root.getiterator("img")
         for count, image in enumerate(images):
             caption = image.attrib["alt"]
+            image_src_frag = image.get("src", "").partition("#")[2]
             image.set("alt", caption)
             parent = parent_map[image]
             idx = list(parent).index(image)
@@ -49,6 +50,7 @@ class FigureTreeprocessor(Treeprocessor):
                 figcap.set("class", self._figcaption_classes)
 
             figure.set("data-title", caption)
+            figure.set("data-options", image_src_frag.replace(",", " "))
             figure.tail = copy(image.tail)
             parent.insert(idx, figure)
             parent.remove(image)

--- a/mdfigure.py
+++ b/mdfigure.py
@@ -80,7 +80,7 @@ class FigureExtension(Extension):
             'figure_classes': [None, "Class attributes assigned to the <figure /> tag"],
             'img_classes': [None, "Class attributes assigned to the <img /> tag"],
             'figcaption_classes': [None, "Class attributes assigned to the <figcaption /> tag"],
-            'multiline': [True, "Support line breaks in <figcaption /> tag"],
+            'multiline': [True, "Support line breaks in the <figcaption /> tag"],
         }
         super(FigureExtension, self).__init__(**kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='markdown-figure',
-    version='0.0.1',
+    version='0.0.2',
 
     author='Jan Willhaus',
     author_email='mail@janwillhaus.de',


### PR DESCRIPTION
Your project, with is seams quite simple but it is awesome. Now documentation looks great with your extension.
I add some improvements, maybe you accept them.

## Multiline caption

```markdown
![First line  
second line](image.png)
```

Keep line breaks (space, space, new-line) and put `<br/>` to `<figcaption/>`.

## Figure options

Everything after `#` in image `src` is put into `<figure/>` attribute `data-options` (comma are changed to space).

Now I can use selectors in the `<figure/>` and set something like `float: right`.

## Docs

A added some text to the `README.md` file. I described configurations (from `py` file) and options.
I think there is a lot of misspells, could you correct it?
